### PR TITLE
Fix two minor texture loading problem

### DIFF
--- a/neural_renderer/load_obj.py
+++ b/neural_renderer/load_obj.py
@@ -48,16 +48,16 @@ def load_textures(filename_obj, filename_mtl, texture_size):
         if line.split()[0] == 'f':
             vs = line.split()[1:]
             nv = len(vs)
-            if '/' in vs[0]:
+            if '/' in vs[0] and '//' not in vs[0]:
                 v0 = int(vs[0].split('/')[1])
             else:
                 v0 = 0
             for i in range(nv - 2):
-                if '/' in vs[i + 1]:
+                if '/' in vs[i + 1] and '//' not in vs[i + 1]:
                     v1 = int(vs[i + 1].split('/')[1])
                 else:
                     v1 = 0
-                if '/' in vs[i + 2]:
+                if '/' in vs[i + 2] and '//' not in vs[i + 2]:
                     v2 = int(vs[i + 2].split('/')[1])
                 else:
                     v2 = 0

--- a/neural_renderer/load_obj.py
+++ b/neural_renderer/load_obj.py
@@ -85,6 +85,14 @@ def load_textures(filename_obj, filename_mtl, texture_size):
     for material_name, filename_texture in texture_filenames.items():
         filename_texture = os.path.join(os.path.dirname(filename_obj), filename_texture)
         image = imread(filename_texture).astype(np.float32) / 255.
+
+        # texture image may have one channel (grey color)
+        if len(image.shape) == 2:
+            image = np.stack((image,)*3,-1)
+        # or has extral alpha channel shoule ignore for now
+        if image.shape[2] == 4:
+            image = image[:,:,:3]
+
         # pytorch does not support negative slicing for the moment
         image = image[::-1, :, :]
         image = torch.from_numpy(image.copy()).cuda()


### PR DESCRIPTION
Two problems:
(1) handle the situation when texture pictures have one channel(grey) or extra alpha channel(transparent). 
(2) .obj file with lines "f xxx//xxx". The value read in should be zero but the original code will read "/" sign and cause an error.