### PR TITLE
fix the ghost problem and divided by zero sum problem

### DIFF
--- a/neural_renderer/cuda/load_textures_cuda_kernel.cu
+++ b/neural_renderer/cuda/load_textures_cuda_kernel.cu
@@ -41,7 +41,7 @@ __global__ void load_textures_cuda_kernel(
   scalar_t dim0 = ((i / (ts * ts)) % ts) / (ts - 1.) ;
   scalar_t dim1 = ((i / ts) % ts) / (ts - 1.);
   scalar_t dim2 = (i % ts) / (ts - 1.);
-  if (1 < dim0 + dim1 + dim2) {
+  if (0 < dim0 + dim1 + dim2) {
       float sum = dim0 + dim1 + dim2;
       dim0 /= sum;
       dim1 /= sum;


### PR DESCRIPTION
The second problem (divided by the zero-sum problem) is due to the dim0 + dim1 + dim2 starts from 0. I test it and believe it is a bug which causes NaN gradient. Therefore I fix it into >0, not follow exactly the same commit made by Kato