### PR TITLE
Fix a bug when saving textured mesh to .obj file.

### DIFF
--- a/neural_renderer/save_obj.py
+++ b/neural_renderer/save_obj.py
@@ -26,7 +26,6 @@ def create_texture_image(textures, texture_size_out=16):
     vertices = vertices.cuda()
     textures = textures.cuda()
     image = create_texture_image_cuda.create_texture_image(vertices, textures, image, 1e-5)
-    image = torch.ones_like(image)
     
     vertices[:, :, 0] /= (image.shape[1] - 1)
     vertices[:, :, 1] /= (image.shape[0] - 1)


### PR DESCRIPTION
In file save_obj.py, there's an excessive line that yields a pure-white texture. 
Maybe it's a better idea to keep the texture image intact so we can save textured models for better display?