### PR TITLE
Fixed a bug in look.py

### DIFF
--- a/neural_renderer/look.py
+++ b/neural_renderer/look.py
@@ -17,7 +17,7 @@ def look(vertices, eye, direction=[0, 1, 0], up=None):
     elif isinstance(direction, np.ndarray):
         direction = torch.from_numpy(direction).to(device)
     elif torch.is_tensor(direction):
-        direction.to(device)
+        direction = direction.to(device)
 
     if isinstance(eye, list) or isinstance(eye, tuple):
         eye = torch.tensor(eye, dtype=torch.float32, device=device)


### PR DESCRIPTION
torch.Tensor.to is not in-place, need an assignment.

Referred to [doc](https://pytorch.org/docs/0.4.0/tensors.html?highlight=#torch.Tensor.to).