### PR TITLE
fix: atomicAdd() is defined twice

### DIFF
--- a/examples/example1.py
+++ b/examples/example1.py
@@ -11,6 +11,7 @@ import imageio
 
 import neural_renderer as nr
 
+
 current_dir = os.path.dirname(os.path.realpath(__file__))
 data_dir = os.path.join(current_dir, 'data')
 
@@ -50,6 +51,7 @@ def main():
         image = images.detach().cpu().numpy()[0].transpose((1, 2, 0))  # [image_size, image_size, RGB]
         writer.append_data((255*image).astype(np.uint8))
     writer.close()
+
 
 if __name__ == '__main__':
     main()

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -49,7 +49,7 @@ class Model(nn.Module):
 
 def make_gif(filename):
     with imageio.get_writer(filename, mode='I') as writer:
-        for filename in sorted(glob.glob('/tmp/_tmp_*.png')):
+        for filename in sorted(glob.glob('./examples/tmp/_tmp_*.png')):
             writer.append_data(imageio.imread(filename))
             os.remove(filename)
     writer.close()
@@ -81,7 +81,7 @@ def main():
         optimizer.step()
         images = model.renderer(model.vertices, model.faces, mode='silhouettes')
         image = images.detach().cpu().numpy()[0]
-        imsave('/tmp/_tmp_%04d.png' % i, image)
+        imsave('./examples/tmp/_tmp_%04d.png' % i, image)
     make_gif(args.filename_output_optimization)
 
     # draw object
@@ -91,7 +91,7 @@ def main():
         model.renderer.eye = nr.get_points_from_angles(2.732, 0, azimuth)
         images, _, _ = model.renderer(model.vertices, model.faces, model.textures)
         image = images.detach().cpu().numpy()[0].transpose((1, 2, 0))
-        imsave('/tmp/_tmp_%04d.png' % num, image)
+        imsave('./examples/tmp/_tmp_%04d.png' % num, image)
     make_gif(args.filename_output_result)
 
 

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -51,7 +51,7 @@ class Model(nn.Module):
 
 def make_gif(filename):
     with imageio.get_writer(filename, mode='I') as writer:
-        for filename in sorted(glob.glob('/tmp/_tmp_*.png')):
+        for filename in sorted(glob.glob('./examples/tmp/_tmp_*.png')):
             writer.append_data(imageio.imread(filename))
             os.remove(filename)
     writer.close()
@@ -84,7 +84,7 @@ def main():
         model.renderer.eye = nr.get_points_from_angles(2.732, 0, azimuth)
         images, _, _ = model.renderer(model.vertices, model.faces, torch.tanh(model.textures))
         image = images.detach().cpu().numpy()[0].transpose((1, 2, 0))
-        imsave('/tmp/_tmp_%04d.png' % num, image)
+        imsave('./examples/tmp/_tmp_%04d.png' % num, image)
     make_gif(args.filename_output)
 
 

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -50,7 +50,7 @@ class Model(nn.Module):
 
 def make_gif(filename):
     with imageio.get_writer(filename, mode='I') as writer:
-        for filename in sorted(glob.glob('/tmp/_tmp_*.png')):
+        for filename in sorted(glob.glob('./examples/tmp/_tmp_*.png')):
             writer.append_data(imread(filename))
             os.remove(filename)
     writer.close()
@@ -91,7 +91,7 @@ def main():
         optimizer.step()
         images, _, _ = model.renderer(model.vertices, model.faces, torch.tanh(model.textures))
         image = images.detach().cpu().numpy()[0].transpose(1,2,0)
-        imsave('/tmp/_tmp_%04d.png' % i, image)
+        imsave('./examples/tmp/_tmp_%04d.png' % i, image)
         loop.set_description('Optimizing (loss %.4f)' % loss.data)
         if loss.item() < 70:
             break

--- a/neural_renderer/cuda/rasterize_cuda_kernel.cu
+++ b/neural_renderer/cuda/rasterize_cuda_kernel.cu
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600 || CUDA_VERSION < 8000)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;

--- a/neural_renderer/load_obj.py
+++ b/neural_renderer/load_obj.py
@@ -10,6 +10,7 @@ import neural_renderer.cuda.load_textures as load_textures_cuda
 texture_wrapping_dict = {'REPEAT': 0, 'MIRRORED_REPEAT': 1,
                          'CLAMP_TO_EDGE': 2, 'CLAMP_TO_BORDER': 3}
 
+
 def load_mtl(filename_mtl):
     '''
     load color (Kd) and filename of textures from *.mtl


### PR DESCRIPTION
Fixed compilation-breaking issue that arises with CUDA 10.0 (possibly also older versions). The fix is taken verbatim from the file THCAtomics.cuh (line 119) of PyTorch 1.1.0 (full path <PythonDir>\Lib\site-packages\torch\include\torch\csrc\api\include\torch\), which avoids duplicate definition of atomicAdd(double*, double).