### PR TITLE
Fixed batching for look transformation

### DIFF
--- a/neural_renderer/look.py
+++ b/neural_renderer/look.py
@@ -33,7 +33,7 @@ def look(vertices, eye, direction=[0, 1, 0], up=None):
     if direction.ndimension() == 1:
         direction = direction[None, :]
     if up.ndimension() == 1:
-        up = up[None, :]
+        up = up.repeat((direction.shape[0], 1))
 
     # create new axes
     z_axis = F.normalize(direction, eps=1e-5)

--- a/neural_renderer/renderer.py
+++ b/neural_renderer/renderer.py
@@ -44,7 +44,7 @@ class Renderer(nn.Module):
             self.perspective = perspective
             self.viewing_angle = viewing_angle
             self.eye = [0, 0, -(1. / math.tan(math.radians(self.viewing_angle)) + 1)]
-            self.camera_direction = [0, 0, 1]
+            self.camera_direction = camera_direction
         else:
             raise ValueError('Camera mode has to be one of projection, look or look_at')
 
@@ -57,7 +57,7 @@ class Renderer(nn.Module):
         self.light_intensity_directional = light_intensity_directional
         self.light_color_ambient = light_color_ambient
         self.light_color_directional = light_color_directional
-        self.light_direction = light_direction 
+        self.light_direction = light_direction
 
         # rasterization
         self.rasterizer_eps = 1e-3
@@ -67,7 +67,7 @@ class Renderer(nn.Module):
         Implementation of forward rendering method
         The old API is preserved for back-compatibility with the Chainer implementation
         '''
-        
+
         if mode is None:
             return self.render(vertices, faces, textures, K, R, t, dist_coeffs, orig_size)
         elif mode is 'rgb':


### PR DESCRIPTION
Fixed minor issue in look transformation where default `up` always has batch size 1. If `direction` or `vertices` are batched, then there's a dimension mismatch.

Also fixed `renderer`'s __init__ not using the `camera_direction` that is passed in as a parameter.