### PR TITLE
AT_CHECK to TORCH_CHECK - PyTorch 1.5 compatible

### DIFF
--- a/neural_renderer/cuda/create_texture_image_cuda.cpp
+++ b/neural_renderer/cuda/create_texture_image_cuda.cpp
@@ -10,8 +10,8 @@ at::Tensor create_texture_image_cuda(
 
 // C++ interface
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) AT_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 
 

--- a/neural_renderer/cuda/load_textures_cuda.cpp
+++ b/neural_renderer/cuda/load_textures_cuda.cpp
@@ -12,8 +12,8 @@ at::Tensor load_textures_cuda(
 
 // C++ interface
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) AT_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 
 

--- a/neural_renderer/cuda/rasterize_cuda.cpp
+++ b/neural_renderer/cuda/rasterize_cuda.cpp
@@ -63,8 +63,8 @@ at::Tensor backward_depth_map_cuda(
 
 // C++ interface
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) AT_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 
 std::vector<at::Tensor> forward_face_index_map(


### PR DESCRIPTION
AT_CHECK is not defined in PyTorch 1.5 and the installation fails - this fix change AT_CHECK to TORCH_CHECK.
However, I'm not sure if it's compatible with all the older PyTorch versions.