### PR TITLE
Fix bug in saving obj file

### DIFF
--- a/neural_renderer/save_obj.py
+++ b/neural_renderer/save_obj.py
@@ -15,7 +15,7 @@ def create_texture_image(textures, texture_size_out=16):
     vertices = torch.zeros((num_faces, 3, 2), dtype=torch.float32)  # [:, :, XY]
     face_nums = torch.arange(num_faces)
     column = face_nums % tile_width
-    row = face_nums / tile_width
+    row = face_nums // tile_width
     vertices[:, 0, 0] = column * texture_size_out
     vertices[:, 0, 1] = row * texture_size_out
     vertices[:, 1, 0] = column * texture_size_out


### PR DESCRIPTION
I found this bug causes incorrect model creation.
This update fixes the erroneous behavior of save_obj function like this:
<img width="711" alt="スクリーンショット 2021-08-04 5 02 45" src="https://user-images.githubusercontent.com/30614789/128080376-838d0e79-c017-45f7-99a6-3aef3706c0af.png">

To this:
<img width="724" alt="スクリーンショット 2021-08-04 5 02 52" src="https://user-images.githubusercontent.com/30614789/128080476-7dbafeb4-62c8-4012-b94d-5455e032789e.png">
